### PR TITLE
History page bugfix: horizontal scroll always shows on desktop devices

### DIFF
--- a/frontend/src/pages/history.module.css
+++ b/frontend/src/pages/history.module.css
@@ -7,5 +7,6 @@
 @media only screen and (min-width: 768px){
     .tableWrapper{
         justify-content: center;
+        overflow: hidden;
     }
 }


### PR DESCRIPTION
Changed overflow:scroll to only apply on mobile