### PR TITLE
Frontend login logic

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,26 +11,47 @@ import ManageProfile from "./pages/manage-profile.js";
 import Navbar from './components/Navbar/Navbar.js'
 import PageContainer from './components/PageContainer/PageContainer';
 import ScrollToTop from './components/ScrollToTop/ScrollToTop';
-
+import {UserAlert} from './components/UserAlert/UserAlert';
 
 function App() {
+  // Login state
   const [loginState, setLoginState] = useLocalStorage('loginState', null)
-  const [isLoggedIn, setIsLoggedIn] = useState(loginState != null ? true : false)
+  const [isLoggedIn, setIsLoggedIn] = useState(loginState != null)
+  const [isFirstLogin, setIsFirstLogin] = useLocalStorage('firstLogin', loginState == null)
 
+  // Alert state (for login/signup)
+  const [openAlert, setOpenAlert] = useState(false);
+  const [alertMessage, setAlertMessage] = useState("");
+
+  // Login state setter
   const setLogin = (uid) =>{
     setLoginState(uid)
     setIsLoggedIn(true)
   }
 
+  // Logout setter
   const handleLogOut = () => {
+    if(isLoggedIn && !isFirstLogin){
+      setAlertMessage(`Successfully logged out.`)
+      setOpenAlert(true)
+      setIsFirstLogin(false)
+    }
     setLoginState(null)
     setIsLoggedIn(false)
+    setIsFirstLogin(true)
   }
 
+  // Login state change handler, for login alert
   useEffect(() => {
-    console.log("loginState updated:", loginState);
+      console.log("loginState updated:", loginState);
+      if(isLoggedIn && isFirstLogin){
+        setAlertMessage(`Successfully logged in: Welcome, ${loginState}!`)
+        setOpenAlert(true)
+        setIsFirstLogin(false)
+      }
   }, [loginState]);
 
+  // MUI theme
   const theme = createTheme({
     palette: {
       primary: {
@@ -62,6 +83,7 @@ function App() {
               <Route path='/manage-profile' element={<ManageProfile/>} />
             </Routes>
           </PageContainer>
+          <UserAlert open={openAlert} setOpen={setOpenAlert} message={alertMessage} severity="success"/>
         </Router>
       </ThemeProvider>
     </div>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { createTheme, ThemeProvider } from "@mui/material/styles";
 import useLocalStorage from 'use-local-storage';
@@ -14,12 +14,22 @@ import ScrollToTop from './components/ScrollToTop/ScrollToTop';
 
 
 function App() {
+  const [loginState, setLoginState] = useLocalStorage('loginState', null)
+  const [isLoggedIn, setIsLoggedIn] = useState(loginState != null ? true : false)
 
-  const [loginState, setLoginState] = useLocalStorage('loginState', false)
-
-  const toggleLogin = () =>{
-    loginState ? setLoginState(false) : setLoginState(true)
+  const setLogin = (uid) =>{
+    setLoginState(uid)
+    setIsLoggedIn(true)
   }
+
+  const handleLogOut = () => {
+    setLoginState(null)
+    setIsLoggedIn(false)
+  }
+
+  useEffect(() => {
+    console.log("loginState updated:", loginState);
+  }, [loginState]);
 
   const theme = createTheme({
     palette: {
@@ -41,13 +51,13 @@ function App() {
         <link href='https://fonts.googleapis.com/css?family=Inter' rel='stylesheet'></link>
         <Router>
         <ScrollToTop />
-        <Navbar login={loginState} toggle={toggleLogin}/>
+        <Navbar login={loginState} toggle={handleLogOut}/>
           <PageContainer>
             <Routes> 
               <Route path='/' element={<Home/>} />
               <Route path='/history' element={<History/>} />
-              <Route path='/login' element={<Login login = {true}/>}/>
-              <Route path='/signup' element={<Login login = {false}/>}/>
+              <Route path='/login' element={<Login login = {true} state={isLoggedIn} setter={setLogin}/>}/>
+              <Route path='/signup' element={<Login login = {false} state={isLoggedIn} setter={setLogin}/>}/>
               <Route path='/estimate' element={<Estimate/>} />
               <Route path='/manage-profile' element={<ManageProfile/>} />
             </Routes>

--- a/frontend/src/components/Navbar/Navbar.js
+++ b/frontend/src/components/Navbar/Navbar.js
@@ -102,7 +102,7 @@ function Navbar(props) {
             </li>
             <li className={styles.loginList}>
               {props.login ? (
-                <Button variant="contained" onClick={props.toggle}>Log Out</Button>
+                <Button variant="outlined" onClick={props.toggle} color="white">Log Out</Button>
               ) : (
                 <Stack direction="row" spacing={2}>
                   <Button variant="contained" onClick={Login} color="primary">Log In</Button>

--- a/frontend/src/components/Navbar/Navbar.js
+++ b/frontend/src/components/Navbar/Navbar.js
@@ -16,8 +16,8 @@ function Navbar(props) {
 
   const theme = useTheme();
 
-  let loginState = props.login /* get and store login state */
-  let loginToggle = props.toggle /* get and store login toggle function */
+  const loginState = props.login /* get and store login state */
+  const loginToggle = props.toggle /* get and store login toggle function */
   
   let navigate = useNavigate(); /* navigate to different pages */
 
@@ -60,8 +60,8 @@ function Navbar(props) {
                   </a>
                 </li>
                 <li className={styles.loginList}>
-                  {loginState ? (
-                    <Button variant="outlined" onClick={loginToggle} color="white">Log Out</Button>
+                  {props.login ? (
+                    <Button variant="outlined" onClick={props.toggle} color="white">Log Out</Button>
                   ) : (
                     <Stack direction="row" spacing={2}>
                       <Button variant="contained" onClick={Login} color="primary">Log In</Button>
@@ -101,8 +101,8 @@ function Navbar(props) {
               </a>
             </li>
             <li className={styles.loginList}>
-              {loginState ? (
-                <Button variant="contained" onClick={props.setLoginState}>Log Out</Button>
+              {props.login ? (
+                <Button variant="contained" onClick={props.toggle}>Log Out</Button>
               ) : (
                 <Stack direction="row" spacing={2}>
                   <Button variant="contained" onClick={Login} color="primary">Log In</Button>

--- a/frontend/src/components/Navbar/Navbar.module.css
+++ b/frontend/src/components/Navbar/Navbar.module.css
@@ -124,6 +124,7 @@ a{
 .loginList{
   display: flex;
   align-items: center;
+  justify-content: center;
 }
 
 /* Tablet */

--- a/frontend/src/components/UserAlert/UserAlert.js
+++ b/frontend/src/components/UserAlert/UserAlert.js
@@ -1,0 +1,21 @@
+import { Snackbar, Alert } from "@mui/material";
+
+export const UserAlert = (props) => {
+    // const [open, setOpen] = useState(false);
+    const { open, setOpen, message, severity } = props;
+    const handleClose = () => {
+        setOpen(false);
+    };
+    return (
+      <Snackbar
+        open={open}
+        autoHideDuration={4000}
+        onClose={handleClose}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+      >
+        <Alert elevation={6} severity={severity} onClose={handleClose}>
+          {message}
+        </Alert>
+      </Snackbar>
+    );
+}

--- a/frontend/src/pages/login.js
+++ b/frontend/src/pages/login.js
@@ -1,4 +1,5 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import SectionTitle from '../components/SectionTitle/SectionTitle'
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
@@ -6,47 +7,59 @@ import Button from '@mui/material/Button';
 
 // TODO: take in props to determine whether user is logging in or registering
 // e.g. if props.login === true, then display "login" button, else display "register" button
-const Login = props => {
-    
-    const [username, setUsername] = useState('');
-    const [password, setPassword] = useState('');
+const Login = (props) => {
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
 
+  const navigate = useNavigate();
 
-    const handleSubmit = (event) => {
-        event.preventDefault();
-        console.log(username);
-    };
-    
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    props.setter(username);
+    props.login
+      ? navigate("/estimate")
+      : navigate("/manage-profile");
+  };
 
-    return(
-        <Box sx={{ mt: 4 }}>
-            <SectionTitle text = {props.login ? 'Log In' : 'Sign Up'}/>
-            <form onSubmit={handleSubmit}>
-                <Box sx={{ mt: 2 }}>
-                    <TextField
-                        id="username"
-                        label="Username"
-                        variant="outlined"
-                        placeholder = "coolgamer123"
-                        value={username}
-                        onChange={(event) => setUsername(event.target.value)}
+  return (
+    <Box sx={{ mt: 4 }}>
+      <SectionTitle text={props.login ? "Log In" : "Sign Up"} />
+      <form onSubmit={handleSubmit}>
+        <Box sx={{ mt: 2 }}>
+          <TextField
+            id="username"
+            label="Username"
+            variant="outlined"
+            placeholder="coolgamer123"
+            inputProps={{ minLength: 4, maxLength: 20 }}
+            required
+            value={username}
+            onChange={(event) => setUsername(event.target.value)}
           />
         </Box>
-        <Box sx={{ mt:2 }}>
+        <Box sx={{ mt: 2 }}>
           <TextField
             id="password"
             label="Password"
             variant="outlined"
-            placeholder = "*********"
+            placeholder="*********"
+            inputProps={{ minLength: 8, maxLength: 30 }}
+            required
             type="password"
             value={password}
             onChange={(event) => setPassword(event.target.value)}
           />
         </Box>
-        <Box sx={{ '& > :not(style)': { m: 2, width: '25ch' }, }}>
-          <Button type="submit" variant="contained" color="primary">
-            {props.login ? 'Log In' : 'Sign Up'}
-          </Button>
+        <Box sx={{ "& > :not(style)": { m: 2, width: "25ch" } }}>
+          {props.state ? (
+            <Button disabled variant="contained">
+              {props.login ? "Log In" : "Sign Up"}
+            </Button>
+          ) : (
+            <Button type="submit" variant="contained" color="primary">
+              {props.login ? "Log In" : "Sign Up"}
+            </Button>
+          )}
         </Box>
       </form>
     </Box>

--- a/frontend/src/pages/manage-profile.js
+++ b/frontend/src/pages/manage-profile.js
@@ -1,4 +1,5 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import SectionTitle from '../components/SectionTitle/SectionTitle'
 import TextField from '@mui/material/TextField';
 import Button from '@mui/material/Button';
@@ -17,7 +18,8 @@ const ManageProfile = props => {
     const [city, setCity] = useState('');
     const [state, setState] = useState('');
     const [zipcode, setZipcode] = useState('');
-
+    const navigate = useNavigate();
+    
     const handleSubmit = (e) => {
         e.preventDefault();
         const data = {
@@ -29,6 +31,7 @@ const ManageProfile = props => {
             zipcode: zipcode,
         }
         console.log(data);
+        navigate("/estimate");
     }
 
     return(


### PR DESCRIPTION
Started on login logic, just on the frontend. 
- Username is stored as a cookie on login/signup
- An alert message displays when users login or log out. 
- Users are now redirected to the estimate page on successful login
- Users redirected to the manage profile page on sign up
- Login and signup forms are greyed out when users are already signed in.

Still need to make an alert for successful profile management submission, and ensure that users can't navigate to other pages before finishing profile management during the signup process (since estimate page depends on user's address). But we can do that later.

Backend implementation should be pretty easy to integrate with this frontend setup.