### PR TITLE
bugfix: history page crashes when accessed by a logged out user

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -86,7 +86,18 @@ function App() {
           <PageContainer>
             <Routes>
               <Route path="/" element={<Home />} />
-              <Route path="/history" element={<History userID={loginID} />} />
+              <Route
+                path="/history"
+                element={
+                  loginID ? (
+                    <History userID={loginID} />
+                  ) : (
+                    <h2 style={{ marginTop: "100px" }}>
+                      Please login to access Estimate History
+                    </h2>
+                  )
+                }
+              />
               <Route
                 path="/login"
                 element={


### PR DESCRIPTION
Implemented conditional rendering of the history page based on user login state, ensuring that history page isn't displayed to users who aren't logged in